### PR TITLE
Fix event bus for config changes

### DIFF
--- a/src/main/java/com/mcjty/mytutorial/Config.java
+++ b/src/main/java/com/mcjty/mytutorial/Config.java
@@ -6,10 +6,11 @@ import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 
 import java.nio.file.Path;
 
-@Mod.EventBusSubscriber
+@Mod.EventBusSubscriber(bus = Bus.MOD)
 public class Config {
 
     public static final String CATEGORY_GENERAL = "general";


### PR DESCRIPTION
I followed your tutorial for 1.14 config - it was really helpful, thanks!

One bug I found - onLoad and onReload weren't firing, because the class wasn't registered on the MOD bus. This is fixed by updating the @EventBusSubscriber annotation. 

